### PR TITLE
144-aws-storage: Added support for AWS EFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Releases Changelog
 
+# 1.1.0
+- Added support for AWS EFS persistent volume through the csi driver `efs.csi.aws.com`
+    To configure it, set in the values file:
+    ```yaml
+    storage:
+    aws:
+        fileSystemId: <your EFS system ID>
+        accessPointId: <Optional, access point id for better permission and isolation management in the EFS>
+    ```
+
 # 1.0.0
 - Version 1.0.0 release. No changes. Only a version bump
 

--- a/controller/helpers/kubernetes_helper.py
+++ b/controller/helpers/kubernetes_helper.py
@@ -107,6 +107,11 @@ class KubernetesV1(BaseK8s, client.CoreV1Api):
                 secret_name=os.getenv("AZURE_SECRET_NAME"),
                 share_name=os.getenv("AZURE_SHARE_NAME")
             )
+        elif os.getenv("AWS_STORAGE_ENABLED"):
+            pv_spec.csi=client.V1CSIPersistentVolumeSource(
+                driver=os.getenv("AWS_STORAGE_DRIVER"),
+                volume_handle=os.getenv("AWS_FILES_SYSTEM_ID")
+            )
         else:
             pv_spec.host_path = client.V1HostPathVolumeSource(
                 path=f"{MOUNT_PATH}/controller/"

--- a/k8s/fn-task-controller/templates/_helpers.tpl
+++ b/k8s/fn-task-controller/templates/_helpers.tpl
@@ -84,3 +84,15 @@ Create the name of the service account to use
 {{- define "fn-alpine" -}}
 ghcr.io/aridhia-open-source/alpine:{{ .Values.fnalpine.tag | default "3.19" }}
 {{- end }}
+
+{{- define "awsStorageAccount" -}}
+{{- if .Values.storage.aws }}
+  {{- with .Values.storage.aws }}
+    {{- if .accessPointId }}
+      {{- printf  "%s::%s" .fileSystemId .accessPointId | quote }}
+    {{- else }}
+      {{- .fileSystemId | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/k8s/fn-task-controller/templates/controller-configmap.yaml
+++ b/k8s/fn-task-controller/templates/controller-configmap.yaml
@@ -14,6 +14,11 @@ data:
   TAG: {{ .Values.controller.tag | default .Chart.AppVersion }}
   IMAGE: {{ template "fn-task-controller.helper-image" . }}
   PUBLIC_URL: {{ .Values.global.host | default "federated-node" }}
+{{- if .Values.storage.aws }}
+  AWS_STORAGE_ENABLED: "true"
+  AWS_STORAGE_DRIVER: "efs.csi.aws.com"
+  AWS_FILES_SYSTEM_ID: {{ include "awsStorageAccount" . }}
+{{- end }}
 {{- if .Values.storage.azure }}
   AZURE_STORAGE_ENABLED: "true"
   AZURE_SHARE_NAME: {{ .Values.storage.azure.shareName }}/controller

--- a/k8s/fn-task-controller/templates/controller-volumes.yaml
+++ b/k8s/fn-task-controller/templates/controller-volumes.yaml
@@ -25,6 +25,10 @@ spec:
     shareName: {{ .Values.storage.azure.shareName }}
     readOnly: false
     secretName: {{ .Values.storage.azure.secretName | default "azure-storage-secret" }}
+  {{ else if .Values.storage.aws }}
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: {{ include "awsStorageAccount" . }}
   {{ else if .Values.storage.nfs }}
   {{ end }}
 ---

--- a/k8s/fn-task-controller/templates/storageclass.yaml
+++ b/k8s/fn-task-controller/templates/storageclass.yaml
@@ -2,14 +2,19 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: controller-results
+volumeBindingMode: WaitForFirstConsumer
 {{ if .Values.storage.local }}
 provisioner: Local
-volumeBindingMode: WaitForFirstConsumer
 {{- else if .Values.storage.azure -}}
 provisioner: disk.csi.azure.com
 parameters:
   skuname: Premium_LRS
-volumeBindingMode: WaitForFirstConsumer
+{{- else if .Values.storage.aws }}
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: {{ include "awsStorageAccount" . }}
+  directoryPerms: "777"
 {{- else if .Values.storage.nfs -}}
 provisioner: {{ .Values.storage.nfs.provisioner -}}
 parameters:


### PR DESCRIPTION
Added support for AWS EFS persistent volume through the csi driver `efs.csi.aws.com`
To configure it, set in the values file:
```yaml
storage:
  aws:
    fileSystemId: <your EFS system ID>
    accessPointId: <Optional, access point id for better permission and isolation management in the EFS>
```