### PR TITLE
configurable-storage-mount-taskcontroller

### DIFF
--- a/controller/const.py
+++ b/controller/const.py
@@ -18,6 +18,7 @@ KC_USER = os.getenv("KC_USER")
 IMAGE = os.getenv("IMAGE")
 TAG = os.getenv("TAG")
 STORAGE_CLASS = os.getenv("STORAGE_CLASS")
+MOUNT_OPTIONS = os.getenv("MOUNT_OPTIONS")
 CRD_GROUP = os.getenv("CRD_GROUP")
 SKIP_USER_AUTH = os.getenv("SKIP_USER_AUTH", "false") == "true"
 HELPER_IMAGE = f"{IMAGE}:{TAG}"

--- a/controller/helpers/kubernetes_helper.py
+++ b/controller/helpers/kubernetes_helper.py
@@ -17,7 +17,8 @@ from kubernetes.client.exceptions import ApiException
 from exceptions import CRDException, KubernetesException
 from const import (
     HELPER_IMAGE, NAMESPACE, MOUNT_PATH,
-    PULL_POLICY, STORAGE_CLASS, KC_USER, KC_HOST, TASK_NAMESPACE
+    PULL_POLICY, STORAGE_CLASS, KC_USER, 
+    KC_HOST, TASK_NAMESPACE, MOUNT_OPTIONS
 )
 from models.crd import Analytics
 
@@ -104,6 +105,7 @@ class KubernetesV1(BaseK8s, client.CoreV1Api):
             access_modes=['ReadWriteMany'],
             capacity={"storage": "100Mi"},
             storage_class_name=STORAGE_CLASS
+            mount_options=MOUNT_OPTIONS.split(",") if MOUNT_OPTIONS else None
         )
         if os.getenv("AZURE_STORAGE_ENABLED"):
             pv_spec.azure_file = client.V1AzureFilePersistentVolumeSource(

--- a/controller/helpers/kubernetes_helper.py
+++ b/controller/helpers/kubernetes_helper.py
@@ -104,7 +104,7 @@ class KubernetesV1(BaseK8s, client.CoreV1Api):
         pv_spec = client.V1PersistentVolumeSpec(
             access_modes=['ReadWriteMany'],
             capacity={"storage": "100Mi"},
-            storage_class_name=STORAGE_CLASS
+            storage_class_name=STORAGE_CLASS,
             mount_options=MOUNT_OPTIONS.split(",") if MOUNT_OPTIONS else None
         )
         if os.getenv("AZURE_STORAGE_ENABLED"):

--- a/k8s/fn-task-controller/templates/controller-configmap.yaml
+++ b/k8s/fn-task-controller/templates/controller-configmap.yaml
@@ -31,4 +31,5 @@ data:
   AZURE_STORAGE_ENABLED: "true"
   AZURE_SHARE_NAME: {{ .Values.storage.azure.shareName }}/controller
   AZURE_SECRET_NAME: {{ .Values.storage.azure.secretName | default "azure-storage-secret" }}
+  MOUNT_OPTIONS: {{ join "," .Values.storage.mountOptions | quote }}
 {{- end }}

--- a/k8s/fn-task-controller/templates/controller-configmap.yaml
+++ b/k8s/fn-task-controller/templates/controller-configmap.yaml
@@ -9,6 +9,7 @@ data:
   BACKEND_HOST: http://backend.{{ .Release.Namespace }}.svc.cluster.local:5000
   KC_HOST: http://keycloak.{{ include "kc_ns" . }}.svc.cluster.local
   GIT_HOME: {{ template "fn-task-controller.gitpath" . }}
+  MOUNT_OPTIONS: {{ join "," .Values.storage.mountOptions | quote }}
   SKIP_USER_AUTH: {{ .Values.controller.skipUserAuth | default false | quote }}
 {{- if .Values.storage.local }}
   MOUNT_PATH: {{ (.Values.storage.local).path }}
@@ -31,5 +32,4 @@ data:
   AZURE_STORAGE_ENABLED: "true"
   AZURE_SHARE_NAME: {{ .Values.storage.azure.shareName }}/controller
   AZURE_SECRET_NAME: {{ .Values.storage.azure.secretName | default "azure-storage-secret" }}
-  MOUNT_OPTIONS: {{ join "," .Values.storage.mountOptions | quote }}
 {{- end }}

--- a/k8s/fn-task-controller/values.schema.json
+++ b/k8s/fn-task-controller/values.schema.json
@@ -147,6 +147,13 @@
             "properties": {
                 "capacity": {
                     "$ref": "#/definitions/capacity"
+                },
+                "mountOptions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
                 }
             },
             "oneOf": [{
@@ -165,6 +172,10 @@
                         "shareName": {
                             "type": "string",
                             "description": "Share name within the azure storage account"
+                        },
+                        "provisioner": {
+                            "type": "string",
+                            "description": "Optional provisioner for the azure storage"
                         }
                     }
                 },

--- a/k8s/fn-task-controller/values.yaml
+++ b/k8s/fn-task-controller/values.yaml
@@ -12,6 +12,7 @@ namespaces:
 
 storage:
   capacity: 1Gi
+  mountOptions: []
   azure:
     # secretName:
     # shareName:


### PR DESCRIPTION
Similar to [feature/configurable-task-storage-mount](https://github.com/Aridhia-Open-Source/PHEMS_federated_node/tree/feature/configurable-task-storage-mount), a way to add custom mount options for the task-controller. 

Still a way to solve [issue 333](https://github.com/Aridhia-Open-Source/PHEMS_federated_node/issues/333).

@liamsmith-Aridhia, I didn't include the test scripts, feel free to add them yourself or send me a message and I'll include them. I'm also not 100% sure if the [values.schema.json](https://github.com/Aridhia-Open-Source/federated-node-task-controller/compare/develop...BrianvanWinden:federated-node-task-controller:main?expand=1#diff-0ea75bbe726862e678ebc7eca3f2b797ff0fb888ddcabcf4c977442b6c2e8532) is correct in the current format. 