### PR TITLE
Fully implement NFS storage support for on-prem installations

### DIFF
--- a/controller/helpers/kubernetes_helper.py
+++ b/controller/helpers/kubernetes_helper.py
@@ -116,6 +116,12 @@ class KubernetesV1(BaseK8s, client.CoreV1Api):
                 driver=os.getenv("AWS_STORAGE_DRIVER"),
                 volume_handle=os.getenv("AWS_FILES_SYSTEM_ID")
             )
+        elif os.getenv("NFS_STORAGE_ENABLED"):
+            pv_spec.nfs = client.V1NFSVolumeSource(
+                server=os.getenv("NFS_SERVER"),
+                path=os.getenv("NFS_PATH"),
+                read_only=False
+            )
         else:
             pv_spec.host_path = client.V1HostPathVolumeSource(
                 path=f"{MOUNT_PATH}/controller/"

--- a/k8s/fn-task-controller/templates/controller-configmap.yaml
+++ b/k8s/fn-task-controller/templates/controller-configmap.yaml
@@ -32,3 +32,8 @@ data:
   AZURE_SHARE_NAME: {{ .Values.storage.azure.shareName }}/controller
   AZURE_SECRET_NAME: {{ .Values.storage.azure.secretName | default "azure-storage-secret" }}
 {{- end }}
+{{- if .Values.storage.nfs }}
+  NFS_STORAGE_ENABLED: "true"
+  NFS_SERVER: {{ .Values.storage.nfs.url }}
+  NFS_PATH: {{ .Values.storage.nfs.path }}/controller
+{{- end }}

--- a/k8s/fn-task-controller/templates/controller-volumes.yaml
+++ b/k8s/fn-task-controller/templates/controller-volumes.yaml
@@ -30,6 +30,10 @@ spec:
     driver: efs.csi.aws.com
     volumeHandle: {{ include "awsStorageAccount" . }}
   {{- else if .Values.storage.nfs }}
+  nfs:
+    server: {{ .Values.storage.nfs.url }}
+    path: {{ .Values.storage.nfs.path }}
+    readOnly: false
   {{- end }}
 ---
 apiVersion: v1

--- a/k8s/fn-task-controller/templates/storageclass.yaml
+++ b/k8s/fn-task-controller/templates/storageclass.yaml
@@ -18,9 +18,7 @@ parameters:
   fileSystemId: {{ include "awsStorageAccount" . }}
   directoryPerms: "777"
 {{- else if .Values.storage.nfs }}
-provisioner: {{ .Values.storage.nfs.provisioner -}}
-parameters:
-  server: {{ .Values.storage.nfs.url -}}
-  path: {{ .Values.storage.nfs.path -}}
-  readOnly: "false"
+provisioner: {{ .Values.storage.nfs.provisioner | default "kubernetes.io/no-provisioner" }}
+mountOptions:
+  - hard
 {{- end }}


### PR DESCRIPTION
NFS storage was partially implemented but broken at the task execution layer, causing silent data loss. Tasks appeared to complete successfully but results were written to a local hostPath on the node rather than the shared NFS volume, making them unreachable by the result-task-job.