### PR TITLE
Use emptydir for git repo clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,5 @@ COPY controller /app/controller
 
 ENV PYTHONPATH=/app/controller
 ENV PATH="/app/.venv/bin:$PATH"
+USER ${USER_UID}
 CMD ["python3", "-m", "controller"]

--- a/build/helper/push_to_github.sh
+++ b/build/helper/push_to_github.sh
@@ -26,25 +26,25 @@ if [ -d "${REPO_FOLDER}" ]; then
     rm -r "${REPO_FOLDER}"
 fi
 echo "Cloning repo"
-gh repo clone "${GH_REPO}" "${REPO_FOLDER}"
+gh repo clone "${GH_REPO}" "${REPO_FOLDER}" -- --depth 1 --no-single-branch --filter=blob:none
 (
     cd "${REPO_FOLDER}" || exit
     git remote remove origin
     git remote add origin https://"$APP_ID:$GH_TOKEN"@github.com/"${GH_REPO}".git
-    git fetch
+    git fetch --depth 1
     BRANCH="${USER_NAME}-${CRD_NAME}-results"
 
     echo "Pulling or creating the results branch"
     if git checkout "${BRANCH}"; then
         git branch --set-upstream-to=origin/"${BRANCH}" "${BRANCH}"
-        git pull
+        git pull --depth 1
     else
         git checkout -b "${BRANCH}"
     fi
 
     mkdir -p "results/${TASK_ID}"
 
-    mv ../*-"${TASK_ID}"-results.zip "results/${TASK_ID}/${TASK_ID}.zip"
+    mv /mnt/results/*-"${TASK_ID}"-results.zip "results/${TASK_ID}/${TASK_ID}.zip"
 
     git add .
     git commit -am "${TASK_ID} Results"

--- a/controller/helpers/kubernetes_helper.py
+++ b/controller/helpers/kubernetes_helper.py
@@ -205,7 +205,13 @@ class KubernetesV1Batch(BaseK8s, client.BatchV1Api):
         specs = client.V1PodSpec(
             containers=[container],
             restart_policy="OnFailure",
-            service_account_name="analytics-operator"
+            service_account_name="analytics-operator",
+            security_context=client.V1PodSecurityContext(
+                run_as_non_root=True,
+                run_as_user=1001,
+                run_as_group=1001,
+                fs_group=1001
+            )
         )
         template = client.V1JobTemplateSpec(
             metadata=metadata,

--- a/controller/helpers/kubernetes_helper.py
+++ b/controller/helpers/kubernetes_helper.py
@@ -280,7 +280,7 @@ class KubernetesV1Batch(BaseK8s, client.BatchV1Api):
             client.V1EnvVar(name="KEY_FILE", value="/mnt/key/key.pem"),
             client.V1EnvVar(name="GH_REPO", value=repository),
             client.V1EnvVar(name="FULL_REPO", value=repository.replace("/", "-")),
-            client.V1EnvVar(name="REPO_FOLDER", value=f"/mnt/results/{name}" if create_volumes else f"/apps/{name}"),
+            client.V1EnvVar(name="REPO_FOLDER", value=f"/mnt/git/{name}" if create_volumes else f"/apps/{name}"),
             client.V1EnvVar(name="GH_CLIENT_ID", value_from=client.V1EnvVarSource(
                 secret_key_ref=client.V1SecretKeySelector(
                     name=f"{secret_name}",
@@ -307,11 +307,23 @@ class KubernetesV1Batch(BaseK8s, client.BatchV1Api):
                     )
                 )
             )
+            volumes.append(
+                client.V1Volume(
+                    name="git",
+                    empty_dir=client.V1EmptyDirVolumeSource()
+                )
+            )
             vol_mounts.append(
                 client.V1VolumeMount(
                     mount_path="/mnt/results/",
                     name="results",
                     sub_path="controller" if os.getenv("AWS_STORAGE_ENABLED") else None
+                )
+            )
+            vol_mounts.append(
+                client.V1VolumeMount(
+                    mount_path="/mnt/git/",
+                    name="git"
                 )
             )
         base_job.spec.template.spec.volumes = volumes

--- a/controller/tests/test_kubernetes.py
+++ b/controller/tests/test_kubernetes.py
@@ -178,6 +178,16 @@ class TestHelperJobVolumeMounts:
         vol_mounts = job_body.spec.template.spec.containers[0].volume_mounts
         return next(m for m in vol_mounts if m.name == "results")
 
+    def _git_volume(self, create_job_mock):
+        job_body = create_job_mock.call_args.kwargs['body']
+        volumes = job_body.spec.template.spec.volumes
+        return next(v for v in volumes if v.name == "git")
+
+    def _git_mount(self, create_job_mock):
+        job_body = create_job_mock.call_args.kwargs['body']
+        vol_mounts = job_body.spec.template.spec.containers[0].volume_mounts
+        return next(m for m in vol_mounts if m.name == "git")
+
     def test_aws_results_mount_uses_controller_subpath(self, mocker, monkeypatch):
         create_job_mock = self._build_helper_job(mocker, monkeypatch, aws_enabled=True)
         assert self._results_mount(create_job_mock).sub_path == "controller"
@@ -185,3 +195,19 @@ class TestHelperJobVolumeMounts:
     def test_non_aws_results_mount_has_no_subpath(self, mocker, monkeypatch):
         create_job_mock = self._build_helper_job(mocker, monkeypatch, aws_enabled=False)
         assert self._results_mount(create_job_mock).sub_path is None
+
+    def test_git_volume_is_empty_dir(self, mocker, monkeypatch):
+        create_job_mock = self._build_helper_job(mocker, monkeypatch)
+        git_vol = self._git_volume(create_job_mock)
+        assert git_vol.empty_dir is not None
+
+    def test_git_mount_path_is_mnt_git(self, mocker, monkeypatch):
+        create_job_mock = self._build_helper_job(mocker, monkeypatch)
+        assert self._git_mount(create_job_mock).mount_path == "/mnt/git/"
+
+    def test_repo_folder_env_uses_git_mount(self, mocker, monkeypatch):
+        create_job_mock = self._build_helper_job(mocker, monkeypatch)
+        job_body = create_job_mock.call_args.kwargs['body']
+        env = job_body.spec.template.spec.containers[0].env
+        repo_folder = next(e for e in env if e.name == "REPO_FOLDER")
+        assert repo_folder.value.startswith("/mnt/git/")

--- a/k8s/fn-task-controller/templates/controller-deployment.yaml
+++ b/k8s/fn-task-controller/templates/controller-deployment.yaml
@@ -21,6 +21,11 @@ spec:
         app: analytics-operator
     spec:
       serviceAccountName: analytics-operator
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       volumes:
         - name: git
           persistentVolumeClaim:
@@ -38,6 +43,10 @@ spec:
           args:
             - -c
             - mkdir -p /mnt/storage/controller
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           volumeMounts:
             - name: git
               mountPath: /mnt/storage
@@ -45,6 +54,10 @@ spec:
           image: "{{ include "fn-task-controller.helper-image" . }}:{{ .Values.controller.tag | default .Chart.AppVersion }}"
           command: ["python3", "-u", "create-controller-user.py"]
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           envFrom:
             - configMapRef:
                 name: controller-config
@@ -59,6 +72,10 @@ spec:
       - name: analytics-operator
         image: {{ template "fn-task-controller.image" . }}:{{ (.Values.controller).tag | default .Chart.AppVersion }}
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         envFrom:
           - configMapRef:
               name: controller-config


### PR DESCRIPTION
Results delivery via GitHub was failing on Azure File storage deployments
 
There are two bugs causing this:
 
The first is that the controller Dockerfile creates a `fednode` user (uid 1001) but never switches to it - there's no `USER` instruction before `CMD`, so the controller runs as root and writes zip files owned by `root:root`. The helper job correctly runs as uid 1001 and can't touch them:
 
```
mv: can't rename '../qc-federatednode.qc.aridhiatest.net-341-results.zip': Operation not permitted
```
 
The second is that even once that's fixed, git clone fails because Azure File shares are mounted over CIFS which doesn't support `chmod`. Git tries to set file permissions immediately after cloning and hits a wall:
 
```
error: chmod on /mnt/results/task-45-results/.git/config.lock failed: Operation not permitted
fatal: could not set 'core.filemode' to 'false'
failed to run git: exit status 128
```
 
The fix for this is to clone the repo into an `emptyDir` instead of directly onto the share.
 