### PR TITLE
Use git clone directly instead of gh (github command line)

### DIFF
--- a/build/helper/push_to_github.sh
+++ b/build/helper/push_to_github.sh
@@ -29,9 +29,6 @@ echo "Cloning repo"
 git clone "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" "${REPO_FOLDER}"
 (
     cd "${REPO_FOLDER}" || exit
-    git remote remove origin
-    git remote add origin https://"$APP_ID:$GH_TOKEN"@github.com/"${GH_REPO}".git
-    git fetch
     BRANCH="${USER_NAME}-${CRD_NAME}-results"
 
     echo "Pulling or creating the results branch"

--- a/build/helper/push_to_github.sh
+++ b/build/helper/push_to_github.sh
@@ -26,7 +26,7 @@ if [ -d "${REPO_FOLDER}" ]; then
     rm -r "${REPO_FOLDER}"
 fi
 echo "Cloning repo"
-gh repo clone "${GH_REPO}" "${REPO_FOLDER}"
+git clone "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" "${REPO_FOLDER}"
 (
     cd "${REPO_FOLDER}" || exit
     git remote remove origin


### PR DESCRIPTION
This patch removes use of `gh` to set up the repo and replaces it with `git clone`. `git clone` simplifies application firewall configuration, as it avoids the use of GitHub's GraphQL API endpoint required by `gh clone`. Since GitHub's GraphQL API uses a single endpoint (api.github.com/graphql) for all operations, it is difficult to define granular firewall rules.